### PR TITLE
(web) Integrate web dev setup with devenv

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -45,4 +45,8 @@
   services.caddy.enable = true;
 
   languages.go.enable = true;
+
+  processes = {
+    web.exec = "pushd ./web > /dev/null && npm install && npm run dev";
+  };
 }


### PR DESCRIPTION
This PR integrates the web dev process with devenv. Once this is merged, we can
do `devenv up` and have a local web server up in dev mode.

Closes #68 