### PR TITLE
Implement full login flow

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -46,14 +46,16 @@ func NewLocalConfig() *Config {
 		Endpoint:     github.Endpoint,
 	}
 
+	webBaseUrl := getEnvOrDie("WEB_BASEURL", "")
+
 	corsConfig := cors.DefaultConfig()
-	corsConfig.AllowOrigins = []string{"http://localhost:5173"}
+	corsConfig.AllowOrigins = []string{webBaseUrl}
 	corsConfig.AllowCredentials = true
 
 	return &Config{
 		ApiDBHandler:           db.NewPostgresHandler(),
 		AuthDBHandler:          db.NewPostgresHandler(),
-		WebBaseUrl:             getEnvOrDie("WEB_BASEURL", ""),
+		WebBaseUrl:             webBaseUrl,
 		ObjectStoreHandler:     objectstore.NewMinIOHandler(),
 		LogLevel:               log.DebugLevel,
 		OAuth2Config:           oauthConfig,
@@ -75,10 +77,16 @@ func NewDevelopmentConfig() *Config {
 		Endpoint:     github.Endpoint,
 	}
 
+	webBaseUrl := getEnvOrDie("WEB_BASEURL", "")
+
+	corsConfig := cors.DefaultConfig()
+	corsConfig.AllowOrigins = []string{webBaseUrl}
+	corsConfig.AllowCredentials = true
+
 	return &Config{
 		ApiDBHandler:           db.NewPostgresHandler(),
 		AuthDBHandler:          db.NewPostgresHandler(),
-		WebBaseUrl:             getEnvOrDie("WEB_BASEURL", ""),
+		WebBaseUrl:             webBaseUrl,
 		ObjectStoreHandler:     objectstore.NewMinIOHandler(),
 		LogLevel:               log.DebugLevel,
 		OAuth2Config:           oauthConfig,
@@ -113,10 +121,17 @@ func NewProductionConfig() *Config {
 		Scopes:       []string{"read-user", "user-email"},
 		Endpoint:     github.Endpoint,
 	}
+
+	webBaseUrl := getEnvOrDie("WEB_BASEURL", "")
+
+	corsConfig := cors.DefaultConfig()
+	corsConfig.AllowOrigins = []string{webBaseUrl}
+	corsConfig.AllowCredentials = true
 	return &Config{
+
 		ApiDBHandler:           db.NewPostgresHandler(),
 		AuthDBHandler:          db.NewPostgresHandler(),
-		WebBaseUrl:             getEnvOrDie("WEB_BASEURL", ""),
+		WebBaseUrl:             webBaseUrl,
 		ObjectStoreHandler:     objectstore.NewMinIOHandler(),
 		LogLevel:               logLevel,
 		OAuth2Config:           oauthConfig,

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -45,6 +45,11 @@ func NewLocalConfig() *Config {
 		Scopes:       []string{"read-user", "user-email"},
 		Endpoint:     github.Endpoint,
 	}
+
+	corsConfig := cors.DefaultConfig()
+	corsConfig.AllowOrigins = []string{"http://localhost:5173"}
+	corsConfig.AllowCredentials = true
+
 	return &Config{
 		ApiDBHandler:           db.NewPostgresHandler(),
 		AuthDBHandler:          db.NewPostgresHandler(),
@@ -54,7 +59,7 @@ func NewLocalConfig() *Config {
 		OAuth2Config:           oauthConfig,
 		MAX_FILE_SIZE_BYTES:    25 << 20, // 25 MB
 		AuthTokenValidDuration: time.Hour * 24,
-		CorsConfig:             cors.Default(),
+		CorsConfig:             cors.New(corsConfig),
 		GinReleaseMode:         gin.DebugMode,
 	}
 }
@@ -69,6 +74,7 @@ func NewDevelopmentConfig() *Config {
 		Scopes:       []string{"read-user", "user-email"},
 		Endpoint:     github.Endpoint,
 	}
+
 	return &Config{
 		ApiDBHandler:           db.NewPostgresHandler(),
 		AuthDBHandler:          db.NewPostgresHandler(),

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -16,6 +16,7 @@ import (
 type Config struct {
 	ApiDBHandler           db.ApiDBHandler
 	AuthDBHandler          db.AuthDBHandler
+	WebBaseUrl             string
 	ObjectStoreHandler     objectstore.ObjectStoreHandler
 	LogLevel               log.Level
 	OAuth2Config           *oauth2.Config
@@ -47,6 +48,7 @@ func NewLocalConfig() *Config {
 	return &Config{
 		ApiDBHandler:           db.NewPostgresHandler(),
 		AuthDBHandler:          db.NewPostgresHandler(),
+		WebBaseUrl:             getEnvOrDie("WEB_BASEURL", ""),
 		ObjectStoreHandler:     objectstore.NewMinIOHandler(),
 		LogLevel:               log.DebugLevel,
 		OAuth2Config:           oauthConfig,
@@ -70,6 +72,7 @@ func NewDevelopmentConfig() *Config {
 	return &Config{
 		ApiDBHandler:           db.NewPostgresHandler(),
 		AuthDBHandler:          db.NewPostgresHandler(),
+		WebBaseUrl:             getEnvOrDie("WEB_BASEURL", ""),
 		ObjectStoreHandler:     objectstore.NewMinIOHandler(),
 		LogLevel:               log.DebugLevel,
 		OAuth2Config:           oauthConfig,
@@ -107,6 +110,7 @@ func NewProductionConfig() *Config {
 	return &Config{
 		ApiDBHandler:           db.NewPostgresHandler(),
 		AuthDBHandler:          db.NewPostgresHandler(),
+		WebBaseUrl:             getEnvOrDie("WEB_BASEURL", ""),
 		ObjectStoreHandler:     objectstore.NewMinIOHandler(),
 		LogLevel:               logLevel,
 		OAuth2Config:           oauthConfig,

--- a/api/controllers/login.go
+++ b/api/controllers/login.go
@@ -49,7 +49,6 @@ func (ctrl *Controller) OAuthCallbackHandler(c *gin.Context) {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
-	log.Info("Print state", "state", state)
 
 	code := c.Query("code")
 	token, err := ctrl.cfg.OAuth2Config.Exchange(c, code)

--- a/api/controllers/login.go
+++ b/api/controllers/login.go
@@ -106,7 +106,7 @@ func (ctrl *Controller) OAuthCallbackHandler(c *gin.Context) {
 	if state.RedirectUri == "" {
 		c.JSON(http.StatusOK, gin.H{
 			"access_token": userAuthToken.Token,
-			"expires_at":  userAuthToken.ExpiresAt,
+			"expires_at":   userAuthToken.ExpiresAt,
 		})
 		return
 	}

--- a/api/controllers/login.go
+++ b/api/controllers/login.go
@@ -1,11 +1,15 @@
 package controllers
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
 	"github.com/Salz-Team/salz/api/models"
 	"github.com/charmbracelet/log"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"strconv"
 
 	ghlib "github.com/google/go-github/v62/github"
 )
@@ -15,14 +19,38 @@ const (
 	DEFAULT_ELO = 1000.0
 )
 
+type State struct {
+	Code        string `json:"code"`
+	RedirectUri string `json:"redirect_uri"`
+}
+
 func (ctrl *Controller) OAuthLoginHandler(c *gin.Context) {
-	url := ctrl.cfg.OAuth2Config.AuthCodeURL("ain't got no state yet")
-	log.Info("Login redirect", "url", url)
-	c.Redirect(http.StatusTemporaryRedirect, url)
+	state := State{
+		Code:        "ain't got no state yet",
+		RedirectUri: c.Query("redirect_uri"),
+	}
+	b, err := json.Marshal(state)
+	if err != nil {
+		log.Error("Could not create state for login", "error", err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	authUrl := ctrl.cfg.OAuth2Config.AuthCodeURL(string(b[:]))
+	log.Info("Login redirect", "url", authUrl)
+	c.Redirect(http.StatusTemporaryRedirect, authUrl)
 }
 
 func (ctrl *Controller) OAuthCallbackHandler(c *gin.Context) {
-	// TODO Check the state to prevent CSRF attacks
+	// TODO Maybe redo encodedState message to do checks to prevent CSRF attacks?
+	encodedState := c.Query("state")
+	var state State
+	if err := json.Unmarshal([]byte(encodedState), &state); err != nil {
+		log.Error("Could not parse state", "error", err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	log.Info("Print state", "state", state)
+
 	code := c.Query("code")
 	token, err := ctrl.cfg.OAuth2Config.Exchange(c, code)
 	if err != nil {
@@ -73,8 +101,24 @@ func (ctrl *Controller) OAuthCallbackHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"access_token": userAuthToken.Token,
-		"expires_at":   userAuthToken.ExpiresAt,
-	})
+	c.Header("Set-Cookie", fmt.Sprintf("Access-Token=%s; Expires=%s; HttpOnly; Secure; SameSite=Lax; Path=/", userAuthToken.Token, userAuthToken.ExpiresAt.Format(http.TimeFormat)))
+
+	webUrl, err := url.JoinPath(ctrl.cfg.WebBaseUrl, "/login/callback")
+	if err != nil {
+		log.Error("Unable to generate web redirect url", "error", err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	redirectUrl, err := http.NewRequest("GET", webUrl, nil)
+	if err != nil {
+		log.Error("Could not create redirect url to web", "error", err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	redirectUrl.URL.RawQuery = url.Values{
+		"redirect_uri": {state.RedirectUri},
+	}.Encode()
+
+	c.Redirect(http.StatusTemporaryRedirect, redirectUrl.URL.String())
 }

--- a/api/run.sh
+++ b/api/run.sh
@@ -12,6 +12,7 @@ export OAUTH_CLIENT_SECRET=$(hcp vault-secrets secrets open github_oauth_client_
 
 # Local environment variables
 export PG_URI="postgres://salz:superdupersecret@localhost:5432/salz?sslmode=disable"
+export WEB_BASEURL="http://localhost:5173"
 export MINIO_ENDPOINT="localhost:9110"
 export MINIO_ACCESS_KEY="minioadmin"
 export MINIO_SECRET_KEY="minioadmin"

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1718384650,
+        "lastModified": 1732025403,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "1f8f5120a654618467692402650323bfc540aa7e",
-        "treeHash": "b80c7f7af9f40be2722b87247f2a45058da37b28",
+        "rev": "6473534b5f3a7ae956ee751084bc4bf2391ccc28",
         "type": "github"
       },
       "original": {
@@ -24,7 +23,6 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
         "type": "github"
       },
       "original": {
@@ -45,7 +43,6 @@
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
         "type": "github"
       },
       "original": {
@@ -56,11 +53,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728492678,
+        "lastModified": 1731676054,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
-        "treeHash": "388c34b3a8d7c53e288436e0767df8ab1112b9a7",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {
@@ -72,16 +68,15 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718229064,
+        "lastModified": 1731797254,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c2ec3a5c2ee9909904f860dadc19bc12cd9cc44",
-        "treeHash": "bc5492bdbd2e237854893983056910e9dab065b3",
+        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -96,11 +91,10 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717664902,
+        "lastModified": 1732021966,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
-        "treeHash": "def977583217aad11744d144c1f7fc216ce450bf",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {

--- a/web/src/lib/api/api.ts
+++ b/web/src/lib/api/api.ts
@@ -4,22 +4,16 @@ import { None } from 'rust-optionals';
 export const getHealth = (apiBaseurl: string) =>
 	get(new URL('/health', apiBaseurl), None(), {}, { mode: 'cors' });
 
-export const login = async (apiBaseurl: string): Promise<string | null> => {
-	const resp = await get(
-		new URL('/login', apiBaseurl),
-		None(),
-		{},
-		{ redirect: 'manual', mode: 'cors' },
+export const login = async (apiBaseurl: string): Promise<void> => {
+	await get(new URL('/login', apiBaseurl), None(), {}, { redirect: 'follow', mode: 'cors' }).then(
+		(resp) => {
+			console.log(resp);
+		},
 	);
-	if (resp.isOk()) {
-		return resp.unwrap().headers.get('location');
-	} else {
-		return null;
-	}
 };
 
 export const getMe = (apiBaseurl: string) =>
-	get(new URL('/users/me', apiBaseurl), None(), {}, { mode: 'cors' });
+	get(new URL('/users/me', apiBaseurl), None(), {}, { mode: 'cors', credentials: 'include' });
 
 export const getUsers = (apiBaseurl: string) =>
-	get(new URL('/users', apiBaseurl), None(), {}, { mode: 'cors' });
+	get(new URL('/users', apiBaseurl), None(), {}, { mode: 'cors', credentials: 'include' });

--- a/web/src/lib/components/OnlineStatus.svelte
+++ b/web/src/lib/components/OnlineStatus.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { type OnlineState } from '$lib/components/types/OnlineStatus';
+	import Icon from '@iconify/svelte';
+	export let onlineState: OnlineState = 'unknown';
+</script>
+
+<aside
+	class="api-online-status"
+	class:is-online={onlineState === 'online'}
+	class:is-offline={onlineState === 'offline'}
+>
+	<Icon icon="tabler:circle-filled" />
+	{#if onlineState === 'online'}
+		online
+	{:else if onlineState === 'offline'}
+		offline
+	{:else}
+		unknown
+	{/if}
+</aside>
+
+<style>
+	.api-online-status {
+		display: inline-flex;
+		align-items: center;
+	}
+
+	.api-online-status > :global(svg) {
+		color: orange;
+	}
+
+	.api-online-status.is-offline > :global(svg) {
+		color: red;
+	}
+
+	.api-online-status.is-online > :global(svg) {
+		color: green;
+	}
+</style>

--- a/web/src/lib/components/types/OnlineStatus.ts
+++ b/web/src/lib/components/types/OnlineStatus.ts
@@ -1,0 +1,1 @@
+export type OnlineState = 'unknown' | 'offline' | 'online';

--- a/web/src/lib/req/index.ts
+++ b/web/src/lib/req/index.ts
@@ -1,4 +1,3 @@
-import type { HttpMethod } from '@sveltejs/kit';
 import { Err, Ok, type Option, type Result } from 'rust-optionals';
 
 export type Resp<T extends Record<string, unknown>> = {
@@ -7,7 +6,7 @@ export type Resp<T extends Record<string, unknown>> = {
 };
 
 export const req = async <T extends Record<string, unknown>>(
-	method: HttpMethod,
+	method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTION',
 	uri: string | URL,
 	body: Option<BodyInit>,
 	headers: Record<string, unknown> = {},
@@ -23,7 +22,7 @@ export const req = async <T extends Record<string, unknown>>(
 			},
 			...fetchOptions,
 		});
-		const respBody = await resp.json();
+		const respBody = resp.body ? await resp.json() : {};
 		const respStatusClass = (resp.status / 100).toPrecision(1);
 		switch (respStatusClass) {
 			case '4':

--- a/web/src/lib/stores/user.ts
+++ b/web/src/lib/stores/user.ts
@@ -5,11 +5,10 @@ export interface UserStore {
 	// Bigint in database, but we'll treat it as a string
 	id: string;
 	username: string;
-	accessToken: string;
 }
 
-export const initialValue = { id: '', username: '', accessToken: '' };
+export const initialValue = { id: '', username: '' };
 
 export const userStore = localWritable('userStore')<UserStore>(initialValue);
 
-export const isLoggedIn = derived(userStore, ($userStore) => Boolean($userStore?.accessToken));
+export const isLoggedIn = derived(userStore, ($userStore) => Boolean($userStore?.id));

--- a/web/src/routes/(all_pages)/login/+page.svelte
+++ b/web/src/routes/(all_pages)/login/+page.svelte
@@ -1,7 +1,24 @@
-<script>
-	import { userStore } from '$lib/stores/user';
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { settingsStore } from '$lib/stores/settings';
+	import { onMount } from 'svelte';
 
-	userStore.set({ id: 'foo', username: 'John Smith', accessToken: 'foo' });
+	onMount(() => {
+		const redirectUri = $page.url.searchParams.get('redirect_uri') ?? '/';
+
+		const url =
+			`${$settingsStore.apiBaseurl}/login` + (redirectUri ? `?redirect_uri=${redirectUri}` : '');
+
+		window.location.href = url;
+	});
 </script>
 
-Login
+<main>Logging in...</main>
+
+<style>
+	main {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+</style>

--- a/web/src/routes/(all_pages)/login/callback/+page.svelte
+++ b/web/src/routes/(all_pages)/login/callback/+page.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import { getMe } from '$lib/api/api';
+	import { settingsStore } from '$lib/stores/settings';
+	import { userStore, isLoggedIn } from '$lib/stores/user';
+	import { onMount } from 'svelte';
+
+	onMount(async () => {
+		if (isLoggedIn) {
+			goto('/');
+		}
+
+		let redirectUrl = decodeURIComponent($page.url.searchParams.get('redirect_uri') ?? '%2F');
+		if (redirectUrl === '') {
+			redirectUrl = '/';
+		}
+		const userResult = await getMe($settingsStore.apiBaseurl);
+		if (userResult.isOk()) {
+			const userResponse = userResult.unwrap();
+			const userid: string = userResponse.body['userid'] as string;
+			const username: string = userResponse.body['username'] as string;
+
+			userStore.set({ id: userid, username });
+
+			goto(redirectUrl);
+		}
+	});
+</script>
+
+<main>Getting your credentials...</main>
+
+<style>
+	main {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+</style>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -24,7 +24,9 @@
 			<NavLink href="/matches"><Icon icon="tabler:video" /> Watch Games</NavLink>
 			<NavLink href="/docs"><Icon icon="tabler:book-2" /> How to play</NavLink>
 			{#if !$isLoggedIn}
-				<NavLink href="/login"><Icon icon="tabler:login" /> Login / Sign up</NavLink>
+				<NavLink href={`/login?redirect_uri=/`}
+					><Icon icon="tabler:login" /> Login / Sign up</NavLink
+				>
 			{/if}
 			{#if $isLoggedIn}
 				<NavLink href="/me"><Icon icon="tabler:user" /> Go to profile</NavLink>


### PR DESCRIPTION
This PR implements the full login flow from the web frontend to the API backend.

There's not much of a surprise here.

Essentially, the flow goes like:

1. User visits `web/login`
2. Gets redirected `api/login`
3. Gets redirected to Github for OAuth2.0 authentication
4. Gets redirected back to `api/login/callback`
5. Gets redirected back to `web/login/callback`
6. Gets redirected to either `web/` or the hinted web uri
