### PR TITLE
Fix fresh db init

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -6,12 +6,6 @@
   env.VAULT_PROJECT_ID = "3196ec06-6d59-4fc4-affa-fa3fdd12cd1c";
   env.VAULT_APP_NAME = "salz";
 
-  # PGHOST, PGPORT already set (probably by devenv?)
-  env.PGUSER = "salz";
-  env.PGPASSWORD = "superdupersecret";
-  env.PGDATABASE = "salz";
-  env.PGREQUIREAUTH = "false";
-
   languages.javascript.enable = true;
   languages.typescript.enable = true;
 
@@ -29,7 +23,7 @@
 
   services.postgres = {
     enable = true;
-    initialDatabases = [{ name = "salz"; schema = ./db/init.sql; }];
+    initialDatabases = [{ name = "salz"; schema = ./db/init.sql; user = "salz"; }];
     initialScript = ''
       CREATE ROLE salz WITH LOGIN PASSWORD 'superdupersecret';
       ALTER ROLE salz WITH SUPERUSER; -- TODO CHANGE THIS IN PROD LOL
@@ -51,4 +45,11 @@
     web.exec = "pushd ./web > /dev/null && npm install && npm run dev";
     api.exec = "pushd ./api > /dev/null && ./run.sh";
   };
+
+  scripts.ppsql.exec = ''
+    export PGUSER=salz
+    export PGPASSWORD=superdupersecret
+    export PGDATABASE=salz
+    psql "$@"
+  '';
 }


### PR DESCRIPTION
If you nuked the db state via `make clean` (i.e. `rm -r .devenv/state/postgres`) and tried to `devenv up postgres`, it would fail because we had some environment variables set. In the database setup it uses those variables and fails because no role has been created (when trying to create the role).

fix: alias `psql` to `ppsql` and cry